### PR TITLE
Colors

### DIFF
--- a/app/assets/javascripts/media_player_wrapper/mejs4_plugin_add_marker_to_playlist.es6
+++ b/app/assets/javascripts/media_player_wrapper/mejs4_plugin_add_marker_to_playlist.es6
@@ -170,7 +170,7 @@ Object.assign(MediaElementPlayer.prototype, {
     clearAddAlert: function() {
       let alertEl = this.alertEl;
 
-      alertEl.classList.remove('alert-success');
+      alertEl.classList.remove('alert-info');
       alertEl.classList.remove('alert-danger');
       $(alertEl)
         .find('p')
@@ -237,7 +237,7 @@ Object.assign(MediaElementPlayer.prototype, {
       let $alertEl = $(alertEl);
       const offset = mejs.Utils.convertSMPTEtoSeconds(startTime);
 
-      alertEl.classList.add('alert-success');
+      alertEl.classList.add('alert-info');
       $alertEl.append('<p>' + response.message + '</p>');
       // Add page refresh message if needed
       if (!t.markersEl) {

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -961,5 +961,5 @@ td {
 
 // Alerts
 .alert-warning {
-  color: #091c44;
+  color: $blueGreen;
 }

--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -791,7 +791,7 @@ h5.panel-title {
 }
 
 .is-invalid {
-  border-color:$danger;
+  border-color: $danger;
 }
 
 .is-invalid:focus {
@@ -881,7 +881,7 @@ h5.panel-title {
 /*Encode dashboard progress bar */
 #encode-records {
   .progress {
-    background-color: #BCBEBF;
+    background-color: #bcbebf;
     text-align: left;
     position: relative;
     height: 13px;
@@ -917,7 +917,6 @@ h5.panel-title {
   display: flex;
 }
 
-
 /* DataTables in Playlists, Timelines, Persona Users, and Encode Dashboard */
 .dataTableToolsTop {
   text-align: right;
@@ -938,13 +937,16 @@ h5.panel-title {
 }
 
 // Action column of each table
-#Playlists, #Timelines, #users-table {
+#Playlists,
+#Timelines,
+#users-table {
   td:last-child {
     white-space: nowrap;
   }
 }
 
-#users-table th, td{
+#users-table th,
+td {
   padding-right: 6px !important;
 }
 
@@ -955,4 +957,9 @@ h5.panel-title {
 
 .btn-light {
   background-color: $btn-light-bg;
+}
+
+// Alerts
+.alert-warning {
+  color: #091c44;
 }

--- a/app/assets/stylesheets/avalon/_buttons.scss
+++ b/app/assets/stylesheets/avalon/_buttons.scss
@@ -42,3 +42,8 @@ button.close {
     text-decoration: none;
   }
 }
+
+.btn-primary:hover {
+  background-color: #336be6;
+  border-color: #336be6;
+}

--- a/app/assets/stylesheets/avalon/_buttons.scss
+++ b/app/assets/stylesheets/avalon/_buttons.scss
@@ -44,6 +44,6 @@ button.close {
 }
 
 .btn-primary:hover {
-  background-color: #336be6;
-  border-color: #336be6;
+  background-color: $primary;
+  border-color: $primary;
 }

--- a/app/assets/stylesheets/avalon/_homepage.scss
+++ b/app/assets/stylesheets/avalon/_homepage.scss
@@ -62,7 +62,7 @@ main.homepage-main {
   bottom: 0;
   color: white;
   width: 100%;
-  background: rgba(9, 28, 68, 0.8);
+  background: $transparentPrimaryDark;
   padding: 2.5rem 0;
   font-family: $museoSlab;
 

--- a/app/assets/stylesheets/avalon/_homepage.scss
+++ b/app/assets/stylesheets/avalon/_homepage.scss
@@ -62,7 +62,7 @@ main.homepage-main {
   bottom: 0;
   color: white;
   width: 100%;
-  background: rgba(42, 84, 89, 0.8);
+  background: rgba(9, 28, 68, 0.8);
   padding: 2.5rem 0;
   font-family: $museoSlab;
 

--- a/app/assets/stylesheets/branding.scss
+++ b/app/assets/stylesheets/branding.scss
@@ -54,6 +54,7 @@ $lightgray: #f2f2f2;
 $red: #d9534f;
 $blue: #2a4d59;
 $lightblue: #31708f;
+$transparentPrimaryDark: rgba(9, 28, 68, 0.8);
 
 /**
   * Bootstrap variable overrides

--- a/app/assets/stylesheets/branding.scss
+++ b/app/assets/stylesheets/branding.scss
@@ -30,21 +30,21 @@ $sansFontFamily: Arial, Helvetica, sans-serif;
 $museoSlab: 'MuseoSlab';
 
 // Primary colors
-$primary: #80a590;
-$primaryDark: #2a5459;
+$primary: #336be6;
+$primaryDark: #091c44;
 $dark: #0a2326;
 
 // Secondary colors
-$yellow: #ffcf08;
-$orange: #fbb040;
+$yellow: #e9bf55;
+$orange: #e9bf55;
 $white: rgb(255, 255, 255);
-$blueGreen: #477076;
+$blueGreen: #091c44;
 
 // Generated palate colors from http://colormind.io/ for Avalon style guide
 // Add new HEX values below to match your organization's flavor of info/success/warning/danger
-$info: #fbb040;
+$info: #e9bf55;
 $success: #429453;
-$warning: #bf841b;
+$warning: #e9bf55;
 $danger: #f44336;
 
 // Colors not from the Styleguide

--- a/app/assets/stylesheets/branding.scss
+++ b/app/assets/stylesheets/branding.scss
@@ -43,7 +43,7 @@ $blueGreen: #091c44;
 // Generated palate colors from http://colormind.io/ for Avalon style guide
 // Add new HEX values below to match your organization's flavor of info/success/warning/danger
 $info: #e9bf55;
-$success: #429453;
+$success: #28a745;
 $warning: #e9bf55;
 $danger: #f44336;
 

--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -185,8 +185,8 @@
 .sort-btn.active,
 .sort-btn.active:hover,
 .sort-btn:hover {
-  color: #091c44;
-  background-color: #e9bf55;
+  color: $blueGreen;
+  background-color: $yellow;
 }
 
 .search-input {

--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -185,8 +185,8 @@
 .sort-btn.active,
 .sort-btn.active:hover,
 .sort-btn:hover {
-  color: #2a5459;
-  background-color: #ffcf08;
+  color: #091c44;
+  background-color: #e9bf55;
 }
 
 .search-input {

--- a/app/views/modules/_flash_messages.html.erb
+++ b/app/views/modules/_flash_messages.html.erb
@@ -22,7 +22,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <div class="container-fluid" id="alerts">
   <% [:success, :notice, :error, :alert].each do |type| %>
     <%- alert_class = case type
-      when :success then "alert-success"
+      when :success then "alert-info"
       when :notice  then "alert-info"
       when :alert   then "alert-warning"
       when :error   then "alert-danger"

--- a/app/views/playlists/_edit_form.html.erb
+++ b/app/views/playlists/_edit_form.html.erb
@@ -225,7 +225,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         },
         success: function(response) {
           // alert success
-          var alert = "<div class='alert alert-success' style='padding:0 10px; margin-bottom: 0;'>";
+          var alert = "<div class='alert alert-info' style='padding:0 10px; margin-bottom: 0;'>";
           alert += "<button type='button' class='close' data-dismiss='alert'>&times;</button>";
           alert += "<span>"+response.message+"</span></div>";
 	  $('#playlist_item_edit_alert_'+id).html(alert)


### PR DESCRIPTION
**Before:**

![Screen Shot 2020-10-09 at 10 20 23 AM](https://user-images.githubusercontent.com/46227821/95594528-105e2e80-0a19-11eb-89d6-33babd4ba6eb.png)

**After:**

<img width="1172" alt="Screen Shot 2020-10-08 at 10 38 57 AM" src="https://user-images.githubusercontent.com/46227821/95594247-b3fb0f00-0a18-11eb-95e9-6295a1798fd3.png">

- Default Avalon colors for backgrounds, buttons, links, and hover states are changed to Emory-branded colors, mostly dark blue and gold
- `.alert-success` messages seem unstyled and visually jarring, so those messages are changed to use the `.alert-info` class (see below)

**Before:**

![Screen Shot 2020-10-09 at 10 16 20 AM](https://user-images.githubusercontent.com/46227821/95594307-c5dcb200-0a18-11eb-9f31-8e64c403d68d.png)

**After:**

![Screen Shot 2020-10-09 at 10 11 58 AM](https://user-images.githubusercontent.com/46227821/95594719-51564300-0a19-11eb-8773-013c182486a9.png)
