### PR TITLE
Fix inaccessible Sass variables

### DIFF
--- a/app/javascript/components/collections/Collection.scss
+++ b/app/javascript/components/collections/Collection.scss
@@ -185,8 +185,8 @@
 .sort-btn.active,
 .sort-btn.active:hover,
 .sort-btn:hover {
-  color: $blueGreen;
-  background-color: $yellow;
+  color: #091c44;
+  background-color: #e9bf55;
 }
 
 .search-input {


### PR DESCRIPTION
- Since the styling for the Collection component is outside the `assets` directory, we have to put in color hex values manually instead of using variables defined in `branding.scss`