### PR TITLE
Adds initial shib config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
         - FEDORA_URL=http://localhost:8080/fcrepo/rest
         - FEDORA_TIMEOUT=300
         - RAILS_ENV=test
+        - DATABASE_AUTH=true
      # Secondary container image on common network.
      - image: postgres:10-alpine
        environment:

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'ims-lti', '~> 1.1.13'
 gem 'net-ldap'
 gem 'omniauth-identity'
 gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git", tag: 'avalon-r4'
+gem 'omniauth-saml', '~> 1.10', '>= 1.10.3'
 
 # Media Access & Transcoding
 gem 'active_encode', '~> 0.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -582,6 +582,9 @@ GEM
     omniauth-identity (1.1.1)
       bcrypt-ruby (~> 3.0)
       omniauth (~> 1.0)
+    omniauth-saml (1.10.3)
+      omniauth (~> 1.3, >= 1.3.2)
+      ruby-saml (~> 1.9)
     orm_adapter (0.5.0)
     os (1.0.1)
     parallel (1.17.0)
@@ -757,6 +760,8 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.10.0)
+    ruby-saml (1.11.0)
+      nokogiri (>= 1.5.10)
     ruby_dep (1.5.0)
     rubydora (1.9.1)
       activemodel
@@ -978,6 +983,7 @@ DEPENDENCIES
   noid-rails (~> 3.0.1)
   omniauth-identity
   omniauth-lti!
+  omniauth-saml (~> 1.10, >= 1.10.3)
   parallel
   pg
   pry-byebug

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -74,6 +74,21 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def shibboleth
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if @user.persisted?
+      sign_in @user
+      # This will help the user go back to where they came.
+      # Refer: https://github.com/omniauth/omniauth/wiki/Saving-User-Location
+      redirect_to request.env["omniauth.origin"] || root_url
+      set_flash_message(:notice, :success, kind: "Shibboleth")
+    else
+      redirect_to root_path
+      set_flash_message(:notice, :failure, kind: "Shibboleth", reason: "you aren't authorized to use this application.")
+    end
+  end
+
   protected :find_user
 
   rescue_from Avalon::MissingUserId do |exception|

--- a/app/models/auth_config.rb
+++ b/app/models/auth_config.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AuthConfig
+  # In production, we use Shibboleth for user authentication,
+  # but in development mode, you may want to use local database
+  # authentication instead.
+  def self.use_database_auth?
+    ENV['DATABASE_AUTH'] == 'true'
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,4 +115,20 @@ config.webpacker.check_yarn_integrity = false
 
   # Additional production specific initializers
   Dir["config/environments/production/*.rb"].each {|file| load file }
+
+  # OmniAuth configuration settings
+  config.idp_slo_target_url = ENV['IDP_SLO_TARGET_URL']
+  config.assertion_consumer_service_url = ENV['ASSERTION_CS_URL']
+  config.assertion_consumer_logout_service_url = ENV['ASSERTION_LOGOUT_URL']
+  config.issuer = ENV['ISSUER']
+  config.idp_sso_target_url = ENV['IDP_SSO_TARGET_URL']
+  config.idp_cert = ENV['IDP_CERT']
+  config.certificate = ENV['SP_CERT']
+  config.private_key = ENV['SP_KEY']
+  config.attribute_statements = {}
+  config.uid_attribute = "urn:oid:0.9.2342.19200300.100.1.1"
+  config.security = {
+     :want_assertions_encrypted  => true, #makes a 2nd KeyDescriptor, this one says use="encryption"
+     :want_assertions_signed  => true, # goes on md SPSSODescriptor tag
+  }
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,16 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  if !Rails.env.development? && !Rails.env.test?
+    provider :shibboleth,
+      :assertion_consumer_service_url        => Rails.application.config.assertion_consumer_service_url,
+      :assertion_consumer_logout_service_url => Rails.application.config.assertion_consumer_logout_service_url,
+      :issuer                                => Rails.application.config.issuer,
+      :idp_sso_target_url                    => Rails.application.config.idp_sso_target_url,
+      :idp_slo_target_url                    => Rails.application.config.idp_slo_target_url,
+      :idp_cert                              => Rails.application.config.idp_cert,
+      :certificate                           => Rails.application.config.certificate,
+      :private_key                           => Rails.application.config.private_key,
+      :attribute_statements                  => Rails.application.config.attribute_statements,
+      :uid_attribute                         => Rails.application.config.uid_attribute,
+      :security                              => Rails.application.config.security
+  end
+end

--- a/db/migrate/20201020210257_add_omniauth_to_users.rb
+++ b/db/migrate/20201020210257_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :display_name, :string
+    add_column :users, :ppid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_195828) do
+ActiveRecord::Schema.define(version: 2020_10_20_210257) do
 
   create_table "active_encode_encode_records", force: :cascade do |t|
     t.string "global_id"
@@ -233,6 +233,8 @@ ActiveRecord::Schema.define(version: 2019_10_16_195828) do
     t.integer "invited_by_id"
     t.string "invited_by_type"
     t.datetime "deleted_at"
+    t.string "display_name"
+    t.string "ppid"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       - SETTINGS__STREAMING__SERVER=nginx
       - SETTINGS__STREAMING__STREAM_TOKEN_TTL=20
       - SYSTEM_GROUPS=administrator,group_manager,manager
+      - DATABASE_AUTH=true
     volumes:
       - .:/home/app/avalon
       - npms:/home/app/avalon/node_modules
@@ -150,6 +151,7 @@ services:
       - RAILS_ENV=test
       - BUNDLE_FLAGS=--with aws test postgres --without production
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
+      - DATABASE_AUTH=true
     ports: []
 
   worker:

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -136,4 +136,44 @@ describe Users::OmniauthCallbacksController, type: :controller do
       end
     end
   end
+
+  describe 'shibboleth login' do
+    before do
+      User.create(provider:     'shibboleth',
+                  uid:          'brianbboys1967',
+                  ppid:         'P0000001',
+                  display_name: 'Brian Wilson',
+                  email:        'brianbboys1967@emory.edu',
+                  username:     'P0000001')
+      request.env["devise.mapping"] = Devise.mappings[:user]
+      request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:shib]
+    end
+    OmniAuth.config.mock_auth[:shib] =
+      OmniAuth::AuthHash.new(
+        provider: 'shibboleth',
+        uid:      "P0000001",
+        info:     {
+          display_name: "Brian Wilson",
+          uid:          'brianbboys1967'
+        }
+      )
+
+    context "when origin is present" do
+      before do
+        request.env["omniauth.origin"] = '/example'
+      end
+
+      it "redirects to origin" do
+        post :shibboleth
+        expect(response.redirect_url).to eq 'http://test.host/example'
+      end
+    end
+
+    context "when origin is missing" do
+      it "redirects to dashboard" do
+        post :shibboleth
+        expect(response.redirect_url).to include 'http://test.host/'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Changes:

* **.circleci/config.yml**: Adds `DATABASE_AUTH` true so that `database_authenticable` can be pushed for testing with CI's docker image.
* **Gemfile**: Adds `omniauth-saml` gem
* **Gemfile.lock**: Updates bundle
* **app/controllers/users/omniauth_callbacks_controller.rb**: Adds shibboleth provider method to find user, log them in, and redirect.
* **app/models/auth_config.rb**: Adds model to check if we are authenticating via database, usually `true` in development.
* **app/models/user.rb**: Adds functionality to be able to find the user in the database else create a new one if first time shibboleth login. Also, assigns display name, ppid, username, and email to user object. **Note:** We are removing registrable and invitable devise modules because we are restricting registrations. Also, changing authentication key to `uid` because password is not a required field for our app.
* **config/environments/production.rb**, **config/initializers/omniauth.rb**: Adds omniauth config settings provided by middleware.
* **docker-compose.yml**: Adds `DATABASE_AUTH` true so that `database_authenticable` can be pushed for development and testing locally.
* **db/***: Adds db table columns
* **spec/***: Adds specs