### PR TITLE
Amends LTI user creation to exclude password creation (#46).

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,8 +86,13 @@ class User < ActiveRecord::Base
   end
 
   def self.create_new_user(username, email, provider)
-    password = Devise.friendly_token[0, 20]
-    create(username: username, email: email, password: password, password_confirmation: password, provider: provider)
+    if provider == 'lti'
+      user = create(username: username, email: email, provider: provider)
+    else
+      password = Devise.friendly_token[0, 20]
+      user = create(username: username, email: email, password: password, password_confirmation: password, provider: provider)
+    end
+    user
   end
 
   def self.find_or_create_by_username_or_email(username, email, provider = 'local')


### PR DESCRIPTION
app/models/user.rb: checks for `lti` provider and forgoes password creation if present.