### PR TITLE
Includes the lti gem's Context into the Application controller (#46).

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   # Adds a few additional behaviors into the application controller
+  include Omniauth::Lti::Context
   include Blacklight::Controller
   include Hydra::Controller::ControllerBehavior
   # To deal with a load order issue breaking persona impersonate


### PR DESCRIPTION
app/controllers/application_controller.rb: Includes the lti gem's Context module.