### PR TITLE
Replaces X-FRAME-OPTIONS with CSP for security purposes [please squash and merge]

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module Avalon
 
     config.active_job.queue_adapter = :sidekiq
 
-    config.action_dispatch.default_headers = { 'X-Frame-Options' => 'ALLOWALL' }
+    config.action_dispatch.default_headers = { "Content-Security-Policy" => "FRAME-ANCESTORS #{ENV["CSP_FRAME_ANCESTORS"]}" }
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do


### PR DESCRIPTION
* In order to protect us from clickjacking attacks, we are removing X-FRAME-OPTIONS header which is allowall by default, and replacing this with a more secure CSP header with certain hosts only.