### PR TITLE
Adds unique scope to email and username

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,8 +31,8 @@ class User < ActiveRecord::Base
 
   devise(*devise_list)
 
-  validates :username, presence: true, uniqueness: { case_sensitive: false }
-  validates :email, presence: true, uniqueness: { case_sensitive: false }
+  validates :username, presence: true, uniqueness: { scope: :provider, case_sensitive: false }
+  validates :email, presence: true, uniqueness: { scope: :provider, case_sensitive: false }
   validate :username_email_uniqueness
 
   before_destroy :remove_bookmarks

--- a/db/migrate/20201207230945_add_unique_index_to_users.rb
+++ b/db/migrate/20201207230945_add_unique_index_to_users.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_index :users, [:username, :provider], unique: true
+    add_index :users, [:email, :provider], unique: true
+  end
+end

--- a/db/migrate/20201207233737_remove_unique_index_from_users.rb
+++ b/db/migrate/20201207233737_remove_unique_index_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveUniqueIndexFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :users, :username
+    remove_index :users, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_20_210257) do
+ActiveRecord::Schema.define(version: 2020_12_07_233737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -266,10 +266,10 @@ ActiveRecord::Schema.define(version: 2020_10_20_210257) do
     t.string "display_name"
     t.string "ppid"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email", "provider"], name: "index_users_on_email_and_provider", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["username"], name: "index_users_on_username", unique: true
+    t.index ["username", "provider"], name: "index_users_on_username_and_provider", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,9 +21,9 @@ describe User, :clean do
 
   describe "validations" do
     it {is_expected.to validate_presence_of(:username)}
-    it {is_expected.to validate_uniqueness_of(:username).case_insensitive}
+    it {is_expected.to validate_uniqueness_of(:username).scoped_to(:provider).case_insensitive}
     it {is_expected.to validate_presence_of(:email)}
-    it {is_expected.to validate_uniqueness_of(:email).case_insensitive}
+    it {is_expected.to validate_uniqueness_of(:email).scoped_to(:provider).case_insensitive}
 
     context 'username and email uniqueness' do
       let(:username) { Faker::Internet.username }


### PR DESCRIPTION
* We are adding scoped provider when checking uniqueness for email and username, because we want to check for uniqueness of email along with the user's provider and not just email or username alone.