### PR TITLE
Changes header for signed in users

### DIFF
--- a/app/views/modules/_user_management.html.erb
+++ b/app/views/modules/_user_management.html.erb
@@ -15,7 +15,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 <%# The containers for the links need to be defined by the calling partial %>
 <% if user_signed_in? %>
-<%= user_key %> | <%= link_to t('auth.sign_out'), main_app.destroy_user_session_path %>
+<%= t('auth.signed_in_header') %> | <%= link_to t('auth.sign_out'), main_app.destroy_user_session_path %>
 <% else %>
 <%= link_to t('auth.sign_in'), main_app.new_user_session_path, :class => "btn btn-info" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
     sign_out: "Sign out"
     embedded_video: <p>This video content is restricted</p><p>You must be logged in and authorized to view it</p>
     embedded_audio: This audio content is restricted
+    signed_in_header: "You are signed in"
   release_label: "Release"
   errors:
     deleted_auth_error: This account has been deleted and cannot be authenticated.

--- a/spec/features/capybara_homepage_spec.rb
+++ b/spec/features/capybara_homepage_spec.rb
@@ -74,7 +74,7 @@ describe 'checks navigation to external links' do
     expect(page).to have_link('Selected Items')
     expect(page).to have_link('Playlists')
     expect(page).to have_link('Sign out')
-    expect(page).to have_content(user.user_key)
+    expect(page).to have_content('You are signed in')
   end
 end
 


### PR DESCRIPTION
* Currently, we are showing username in the header for signed in users,
however, usernames from canvas are long strings which we don't need to show to users. We are removing that string and replacing it with simple text that says a user is signed in.

output:
![image](https://user-images.githubusercontent.com/17075287/102281930-d2d8be80-3efd-11eb-8719-ee2887727d2f.png)
