### PR TITLE
Removes search bar from header

### DIFF
--- a/app/views/modules/_header.html.erb
+++ b/app/views/modules/_header.html.erb
@@ -36,12 +36,6 @@ Unless required by applicable law or agreed to in writing, software distributed
         </div>
       </div>
 
-      <% unless current_page?(main_app.root_path) %>
-      <div class="header-search">
-        <%= render :partial=>'modules/avalon_search_form' %>
-      </div>
-      <% end %>
-
       <%# By default shift log in / log out to the header %>
       <div class="text-right log-in-out text-muted header-user">
         <%= render 'modules/user_management' %>

--- a/spec/features/capybara_homepage_spec.rb
+++ b/spec/features/capybara_homepage_spec.rb
@@ -76,6 +76,12 @@ describe 'checks navigation to external links' do
     expect(page).to have_link('Sign out')
     expect(page).to have_content('You are signed in')
   end
+  it 'verifies search box is not present in header after login' do
+    user = FactoryBot.create(:administrator)
+    login_as user, scope: :user
+    visit'/catalog?q=&search_field=all_fields'
+    expect(page).not_to have_content('Emory Libraries\nSearch') # verifying a longer, more unqiue string; since there is `Search` for other things on the page
+  end
 end
 
 describe 'Sign in page' do


### PR DESCRIPTION
* On narrow screens the search box takes up an odd space, and we don't really want to encourage users to search the site.

output (search box is not present after login):

![image](https://user-images.githubusercontent.com/17075287/102420315-df2d4c00-3fcf-11eb-937a-0df90fa291ff.png)
