### PR TITLE
Removes duplicate login options for saml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,11 +82,6 @@ auth:
     #     :oauth_credentials:
     #       <%= ENV['LTI_AUTH_KEY'] %>: <%= ENV['LTI_AUTH_SECRET'] %>
     # <% end %>
-    <% if ENV['SP_KEY'] %>
-    - :name: Saml
-      :provider: :saml
-      :hidden: false
-    <% end %>
 # google_analytics_tracking_id: "someid"
 supplemental_files:
   proxy: false


### PR DESCRIPTION
* Removing this duplicate saml config from settings yaml will take the user directly to shib, since we do not have any other sign in methods. This config is already present in `authentication.rb` file.

No screenshot to present. When this gets deployed, clicking `sign in` will take the user directly to shib.