### PR TITLE
Pins ruby-saml to secure version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'net-ldap'
 gem 'omniauth-identity'
 gem 'omniauth-lti', git: "https://github.com/avalonmediasystem/omniauth-lti.git", tag: 'avalon-r4'
 gem 'omniauth-saml', '~> 1.10', '>= 1.10.3'
+gem 'ruby-saml', '1.12.4'
 
 # Media Access & Transcoding
 gem 'active_encode', '~> 0.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1331,7 +1331,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashdiff (0.3.9)
-    hashie (3.6.0)
+    hashie (5.0.0)
     hooks (0.4.1)
       uber (~> 0.0.14)
     htmlentities (4.3.4)
@@ -1438,7 +1438,7 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.0)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.2.10)
     multi_json (1.13.1)
@@ -1455,8 +1455,8 @@ GEM
     noid-rails (3.0.1)
       actionpack (>= 5.0.0, < 6)
       noid (~> 0.9)
-    nokogiri (1.11.3)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     nom-xml (1.1.0)
       activesupport (>= 3.2.18)
@@ -1475,8 +1475,8 @@ GEM
       activesupport
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
-    omniauth (1.9.0)
-      hashie (>= 3.4.6, < 3.7.0)
+    omniauth (1.9.2)
+      hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
     omniauth-identity (1.1.1)
       bcrypt-ruby (~> 3.0)
@@ -1507,8 +1507,8 @@ GEM
     puma (4.3.5)
       nio4r (~> 2.0)
     raabro (1.3.1)
-    racc (1.5.2)
-    rack (2.2.3)
+    racc (1.8.1)
+    rack (2.2.13)
     rack-cors (1.1.0)
       rack (>= 2.0.0)
     rack-protection (2.0.7)
@@ -1622,6 +1622,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
+    rexml (3.4.1)
     roo (2.8.2)
       nokogiri (~> 1)
       rubyzip (>= 1.2.1, < 2.0.0)
@@ -1666,8 +1667,9 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.10.0)
-    ruby-saml (1.11.0)
-      nokogiri (>= 1.5.10)
+    ruby-saml (1.12.4)
+      nokogiri (>= 1.10.5)
+      rexml
     ruby_dep (1.5.0)
     rubydora (1.9.1)
       activemodel
@@ -1921,6 +1923,7 @@ DEPENDENCIES
   rspec-rails
   rspec-retry
   rspec_junit_formatter
+  ruby-saml (= 1.12.4)
   samvera-persona (~> 0.1.7)
   sass (= 3.4.22)
   sass-rails (~> 5.0)


### PR DESCRIPTION
Per https://thehackernews.com/2025/03/github-uncovers-new-ruby-saml.html, the secure versions of `ruby-saml` are 1.12.4 or >=1.18.0. Since the highest version of `ruby-saml` this application can accept is 1.14.0, I opted for 1.12.4. 